### PR TITLE
fix: prevent zoom to input on mobile

### DIFF
--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -146,7 +146,7 @@ export default function Index() {
                 name="name"
                 defaultValue={values["name"]}
                 className={classNames(
-                  "input input-bordered input-md w-full max-w-xs",
+                  "input input-bordered input-md w-full max-w-xs text-base",
                   errors.name && "input-error"
                 )}
               />
@@ -167,7 +167,7 @@ export default function Index() {
                 name="status"
                 defaultValue={values["status"]}
                 className={classNames(
-                  "input input-bordered input-md w-full max-w-xs",
+                  "input input-bordered input-md w-full max-w-xs text-base",
                   errors.status && "input-error"
                 )}
               />


### PR DESCRIPTION
see https://css-tricks.com/16px-or-larger-text-prevents-ios-form-zoom/